### PR TITLE
Fix memory size avoiding oom-killed

### DIFF
--- a/deploy/k8s.yaml.tmpl
+++ b/deploy/k8s.yaml.tmpl
@@ -71,10 +71,10 @@ spec:
         resources:
           limits:
             cpu: 1000m
-            memory: 1.5Gi
+            memory: 2Gi
           requests:
             cpu: 250m
-            memory: 900Mi
+            memory: 1Gi
 ---
 # Service
 apiVersion: v1


### PR DESCRIPTION
• Increase the memory size to avoid oom-killed (62 restarts on last days)  

![image](https://user-images.githubusercontent.com/8668026/71987427-ecad5400-320c-11ea-93b7-fb675e9b4a97.png)
![image](https://user-images.githubusercontent.com/8668026/71987437-f040db00-320c-11ea-8029-82112059e533.png)
